### PR TITLE
Add QtModelsToolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Pull requests of new projects/apps/libraries are welcome :)
 * [QMarkdownTextEdit](https://github.com/pbek/qmarkdowntextedit) - A C++ Qt QPlainTextEdit widget with markdown highlighting support and some other extras.
 * [QSourceHighlite](https://github.com/Waqar144/QSourceHighlite) - A lightweight source code/syntax highlighter written in Qt C++.
 * [QmlTreeViewExample](https://github.com/ArtifeksNN/QmlTreeViewExample) - Here is an example of how a tree might look in QML.
+* [QtModelsToolkit](https://github.com/status-im/QtModelsToolkit) - Collection of Qt proxy models and other models-related utilities.
 
 
 ## Multimedia


### PR DESCRIPTION
Adds [QtModelsToolkit](https://github.com/status-im/QtModelsToolkit) - collection of proxy models for handy models manipulation on the qml side.